### PR TITLE
feat: in-memory caching for service fetchers

### DIFF
--- a/app/services/consumet/anilist/anilist.server.ts
+++ b/app/services/consumet/anilist/anilist.server.ts
@@ -1,3 +1,4 @@
+import { lruCache } from '~/services/lru-cache';
 import Anilist from './utils.server';
 import {
   IAnimeSearch,
@@ -11,8 +12,15 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fetcher = async <T = any>(url: string): Promise<T> => {
+  const cached = lruCache.get<T>(url);
+  if (cached) return cached;
+
   const res = await fetch(url);
-  return res.json();
+  const data = await res.json();
+
+  lruCache.set(url, data);
+
+  return data;
 };
 
 export const getAnimeSearch = async (

--- a/app/services/consumet/anilist/anilist.server.ts
+++ b/app/services/consumet/anilist/anilist.server.ts
@@ -19,6 +19,7 @@ const fetcher = async <T = any>(url: string): Promise<T> => {
   }
 
   const res = await fetch(url);
+  if (!res.ok) throw new Error(JSON.stringify(await res.json()));
   const data = await res.json();
 
   lruCache.set(url, data);

--- a/app/services/consumet/anilist/anilist.server.ts
+++ b/app/services/consumet/anilist/anilist.server.ts
@@ -13,7 +13,10 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fetcher = async <T = any>(url: string): Promise<T> => {
   const cached = lruCache.get<T>(url);
-  if (cached) return cached;
+  if (cached) {
+    console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
+    return cached;
+  }
 
   const res = await fetch(url);
   const data = await res.json();

--- a/app/services/consumet/flixhq/flixhq.server.ts
+++ b/app/services/consumet/flixhq/flixhq.server.ts
@@ -1,10 +1,18 @@
+import { lruCache } from '~/services/lru-cache';
 import Flixhq from './utils.server';
 import { IMovieSearch, IMovieInfo, IMovieEpisodeStreamLink } from './flixhq.types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fetcher = async <T = any>(url: string): Promise<T> => {
+  const cached = lruCache.get<T>(url);
+  if (cached) return cached;
+
   const res = await fetch(url);
-  return res.json();
+  const data = await res.json();
+
+  lruCache.set(url, data);
+
+  return data;
 };
 
 export const getMovieSearch = async (

--- a/app/services/consumet/flixhq/flixhq.server.ts
+++ b/app/services/consumet/flixhq/flixhq.server.ts
@@ -11,6 +11,7 @@ const fetcher = async <T = any>(url: string): Promise<T> => {
   }
 
   const res = await fetch(url);
+  if (!res.ok) throw new Error(JSON.stringify(await res.json()));
   const data = await res.json();
 
   lruCache.set(url, data);

--- a/app/services/consumet/flixhq/flixhq.server.ts
+++ b/app/services/consumet/flixhq/flixhq.server.ts
@@ -5,7 +5,10 @@ import { IMovieSearch, IMovieInfo, IMovieEpisodeStreamLink } from './flixhq.type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fetcher = async <T = any>(url: string): Promise<T> => {
   const cached = lruCache.get<T>(url);
-  if (cached) return cached;
+  if (cached) {
+    console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
+    return cached;
+  }
 
   const res = await fetch(url);
   const data = await res.json();

--- a/app/services/loklok.ts
+++ b/app/services/loklok.ts
@@ -1,3 +1,0 @@
-export * from './loklok/movie.server';
-export * from './loklok/tv.server';
-export * from './loklok/media.server';

--- a/app/services/loklok/index.ts
+++ b/app/services/loklok/index.ts
@@ -1,0 +1,3 @@
+export * from './movie.server';
+export * from './tv.server';
+export * from './media.server';

--- a/app/services/loklok/utils.server.ts
+++ b/app/services/loklok/utils.server.ts
@@ -1,12 +1,22 @@
+import { lruCache } from '../lru-cache';
+
 export const LOKLOK_URL = 'https://loklok.vercel.app/api';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const fetcher = async <T = any>(url: string): Promise<T> => {
+  const cached = lruCache.get<T>(url);
+
+  if (cached) return cached;
+
   const res = await fetch(url);
 
   // throw error here
   if (!res.ok)
     throw new Error(`fetcher (loklok-server): ${url}${JSON.stringify(await res.json())}`);
 
-  return res.json();
+  const data = await res.json();
+
+  lruCache.set(url, data);
+
+  return data;
 };

--- a/app/services/loklok/utils.server.ts
+++ b/app/services/loklok/utils.server.ts
@@ -6,7 +6,10 @@ export const LOKLOK_URL = 'https://loklok.vercel.app/api';
 export const fetcher = async <T = any>(url: string): Promise<T> => {
   const cached = lruCache.get<T>(url);
 
-  if (cached) return cached;
+  if (cached) {
+    console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
+    return cached;
+  }
 
   const res = await fetch(url);
 

--- a/app/services/lru-cache.ts
+++ b/app/services/lru-cache.ts
@@ -1,0 +1,39 @@
+import LRU from 'lru-cache';
+
+// https://www.npmjs.com/package/lru-cache
+
+// eslint-disable-next-line import/no-mutable-exports
+let lruCache: LRU<string, unknown>;
+
+declare global {
+  // eslint-disable-next-line vars-on-top, no-var
+  var cache: LRU<string, unknown> | undefined;
+}
+
+const options = {
+  // let just say 1kb is an object which after being stringified having length of 1000
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+  sizeCalculation: (_value: unknown, _key: string) =>
+    Math.ceil(JSON.stringify(_value).length / 1000),
+
+  // we won't cache object bigger than 50kb
+  maxSize: 50,
+
+  // max nb of objects, less than 250mb
+  max: 5000,
+
+  // how long to live in ms
+  ttl: 1000 * 60 * 60 * 24, // one day
+};
+
+if (process.env.NODE_ENV === 'production') {
+  lruCache = new LRU(options);
+} else {
+  if (!global.cache) {
+    global.cache = new LRU(options);
+  }
+  lruCache = global.cache;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export { lruCache };

--- a/app/services/open-subtitles/open-subtitles.server.ts
+++ b/app/services/open-subtitles/open-subtitles.server.ts
@@ -9,7 +9,10 @@ const fetcher = async <T = any>(
   body?: { file_id: number },
 ): Promise<T> => {
   const cached = lruCache.get<T>(url);
-  if (cached) return cached;
+  if (cached) {
+    console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
+    return cached;
+  }
 
   const myHeaders = new Headers();
   myHeaders.append('Api-Key', `${process.env.OPEN_SUBTITLES_API_KEY}`);
@@ -21,6 +24,7 @@ const fetcher = async <T = any>(
     ...(body && { body: JSON.stringify(body) }),
   };
   const res = await fetch(url, init);
+  if (!res.ok) throw new Error(JSON.stringify(await res.json()));
   const data = await res.json();
 
   lruCache.set(url, data);

--- a/app/services/tmdb/utils.server.ts
+++ b/app/services/tmdb/utils.server.ts
@@ -342,7 +342,10 @@ export class TMDB {
 
 export const fetcher = async <T = any>(url: string): Promise<T> => {
   const cached = lruCache.get<T>(url);
-  if (cached) return cached;
+  if (cached) {
+    console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
+    return cached;
+  }
 
   const res = await fetch(url);
 

--- a/app/services/tmdb/utils.server.ts
+++ b/app/services/tmdb/utils.server.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/indent */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { lruCache } from '../lru-cache';
 import {
   BackdropSize,
   IMedia,
@@ -340,12 +341,18 @@ export class TMDB {
 }
 
 export const fetcher = async <T = any>(url: string): Promise<T> => {
+  const cached = lruCache.get<T>(url);
+  if (cached) return cached;
+
   const res = await fetch(url);
 
   // throw error here
   if (!res.ok) throw new Error(JSON.stringify(await res.json()));
+  const data = await res.json();
 
-  return res.json();
+  lruCache.set(url, data);
+
+  return data;
 };
 
 export const postFetchDataHandler = (data: any, mediaType?: 'movie' | 'tv'): IMedia[] => {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "i18next-fs-backend": "^1.1.5",
     "i18next-http-backend": "^1.4.1",
     "lottie-web": "^5.9.6",
+    "lru-cache": "^7.14.0",
     "next-themes": "^0.2.0",
     "nprogress": "^0.2.0",
     "photoswipe": "^5.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6628,7 +6628,7 @@ lru-cache@^7.10.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.13.2.tgz#bb5d3f1deea3f3a7a35c1c44345566a612e09cd0"
   integrity sha512-VJL3nIpA79TodY/ctmZEfhASgqekbT574/c4j3jn4bKXbSCnTTCH/KltZyvL2GlV+tGSMtsWyem8DCX7qKTMBA==
 
-lru-cache@^7.10.1:
+lru-cache@^7.10.1, lru-cache@^7.14.0:
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.0.tgz#21be64954a4680e303a09e9468f880b98a0b3c7f"
   integrity sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==


### PR DESCRIPTION
#200
- with [lru-cache](https://www.npmjs.com/package/lru-cache)
- if url has been fetched and cached once, serve cached data, else send fetch request, cache and return the fetched data
- this caching is in internal memory, so does not survive server restart

Why ? Vercel can take care of these stuff.
IDK 😅 I think vercel cache what have been requested by users, but not by server itself ?

Page like HomePage fetch Trending, Popular Movie/TvShow/People. If we visit Trending Page, server does not need to fetch Trending/page1 again.