### PR TITLE
feat: lru_cache mode on/off for some dev purpose

### DIFF
--- a/app/services/consumet/anilist/anilist.server.ts
+++ b/app/services/consumet/anilist/anilist.server.ts
@@ -13,17 +13,19 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fetcher = async <T = any>(url: string): Promise<T> => {
-  const cached = lruCache.get<T>(url);
-  if (cached) {
-    console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
-    return cached;
+  if (lruCache) {
+    const cached = lruCache.get<T>(url);
+    if (cached) {
+      console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
+      return cached;
+    }
   }
 
   const res = await fetch(url);
   if (!res.ok) throw new Error(JSON.stringify(await res.json()));
   const data = await res.json();
 
-  lruCache.set(url, data);
+  if (lruCache) lruCache.set(url, data);
 
   return data;
 };

--- a/app/services/consumet/flixhq/flixhq.server.ts
+++ b/app/services/consumet/flixhq/flixhq.server.ts
@@ -4,17 +4,19 @@ import { IMovieSearch, IMovieInfo, IMovieEpisodeStreamLink } from './flixhq.type
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fetcher = async <T = any>(url: string): Promise<T> => {
-  const cached = lruCache.get<T>(url);
-  if (cached) {
-    console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
-    return cached;
+  if (lruCache) {
+    const cached = lruCache.get<T>(url);
+    if (cached) {
+      console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
+      return cached;
+    }
   }
 
   const res = await fetch(url);
   if (!res.ok) throw new Error(JSON.stringify(await res.json()));
   const data = await res.json();
 
-  lruCache.set(url, data);
+  if (lruCache) lruCache.set(url, data);
 
   return data;
 };

--- a/app/services/loklok/utils.server.ts
+++ b/app/services/loklok/utils.server.ts
@@ -4,11 +4,13 @@ export const LOKLOK_URL = 'https://loklok.vercel.app/api';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const fetcher = async <T = any>(url: string): Promise<T> => {
-  const cached = lruCache.get<T>(url);
+  if (lruCache) {
+    const cached = lruCache.get<T>(url);
 
-  if (cached) {
-    console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
-    return cached;
+    if (cached) {
+      console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
+      return cached;
+    }
   }
 
   const res = await fetch(url);
@@ -19,7 +21,7 @@ export const fetcher = async <T = any>(url: string): Promise<T> => {
 
   const data = await res.json();
 
-  lruCache.set(url, data);
+  if (lruCache) lruCache.set(url, data);
 
   return data;
 };

--- a/app/services/lru-cache.ts
+++ b/app/services/lru-cache.ts
@@ -1,9 +1,10 @@
 import LRU from 'lru-cache';
+import { env } from 'process';
 
 // https://www.npmjs.com/package/lru-cache
 
 // eslint-disable-next-line import/no-mutable-exports
-let lruCache: LRU<string, unknown>;
+let lruCache: LRU<string, unknown> | undefined;
 
 declare global {
   // eslint-disable-next-line vars-on-top, no-var
@@ -26,9 +27,9 @@ const options = {
   ttl: 1000 * 60 * 60 * 24, // one day
 };
 
-if (process.env.NODE_ENV === 'production') {
+if (env.NODE_ENV === 'production') {
   lruCache = new LRU(options);
-} else {
+} else if (env.LRU_CACHE !== 'OFF') {
   if (!global.cache) {
     global.cache = new LRU(options);
   }

--- a/app/services/open-subtitles/open-subtitles.server.ts
+++ b/app/services/open-subtitles/open-subtitles.server.ts
@@ -8,10 +8,12 @@ const fetcher = async <T = any>(
   method: string,
   body?: { file_id: number },
 ): Promise<T> => {
-  const cached = lruCache.get<T>(url);
-  if (cached) {
-    console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
-    return cached;
+  if (lruCache) {
+    const cached = lruCache.get<T>(url);
+    if (cached) {
+      console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
+      return cached;
+    }
   }
 
   const myHeaders = new Headers();
@@ -27,7 +29,7 @@ const fetcher = async <T = any>(
   if (!res.ok) throw new Error(JSON.stringify(await res.json()));
   const data = await res.json();
 
-  lruCache.set(url, data);
+  if (lruCache) lruCache.set(url, data);
 
   return data;
 };

--- a/app/services/tmdb/utils.server.ts
+++ b/app/services/tmdb/utils.server.ts
@@ -347,10 +347,12 @@ export class TMDB {
 }
 
 export const fetcher = async <T = any>(url: string): Promise<T> => {
-  const cached = lruCache.get<T>(url);
-  if (cached) {
-    console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
-    return cached;
+  if (lruCache) {
+    const cached = lruCache.get<T>(url);
+    if (cached) {
+      console.info('\x1b[32m%s\x1b[0m', '[cached]', url);
+      return cached;
+    }
   }
 
   const res = await fetch(url);
@@ -359,7 +361,7 @@ export const fetcher = async <T = any>(url: string): Promise<T> => {
   if (!res.ok) throw new Error(JSON.stringify(await res.json()));
   const data = await res.json();
 
-  lruCache.set(url, data);
+  if (lruCache) lruCache.set(url, data);
 
   return data;
 };


### PR DESCRIPTION
LRU cache mode: 

- production: always on
- development: on by default, off only when env.LRU_CACHE=OFF

Cases needs: wanna test some url fetching but the url already has been cached, fetch is not called

Closes #200 